### PR TITLE
refactor: max id on insert route

### DIFF
--- a/app/exceptions/product_exceptions.py
+++ b/app/exceptions/product_exceptions.py
@@ -2,7 +2,7 @@ class ProductNotFoundError(Exception):
     def __init__(self, id: int, message: str=None):
         self.id = id
 
-        message = message or f"Product id {id} not found."
+        message = message or f"Product ID {id} not found."
         super().__init__(message)
 
 class ValidationError(Exception):

--- a/app/repositories/product_repository.py
+++ b/app/repositories/product_repository.py
@@ -42,7 +42,12 @@ class ProductRepository:
     @staticmethod
     def insert_product(name: str, category: str, barcode: str, price: float):
         try:
-            id = len(ProductRepository.products) + 1
+            if ProductRepository.products:
+                max_id = max(ProductRepository.products)
+            else:
+                max_id = 0
+            
+            id = max_id + 1
             product = Product(id, name, category, barcode, price)
             ProductRepository.products[id] = product
 


### PR DESCRIPTION
Change "len" to "max" when searching for the max ID in the dict. The use of "len" would be a problem when deleting a product that wasn't the last one.

Ex.: we have 3 products (ID 1, 2, 3). We delete product ID 1. Using len, when we try to insert another product, we would try to insert ID 3 again.